### PR TITLE
Retry on failed sync

### DIFF
--- a/cloudify_tf/tasks.py
+++ b/cloudify_tf/tasks.py
@@ -196,6 +196,7 @@ def _state_pull(tf):
         tf_output = tf.output()
     except Exception as ex:
         _, _, tb = sys.exc_info()
+        # TODO: make sure it's recoverable only on not syncing plugins
         raise RecoverableError(
             "Failed pulling state",
             causes=[exception_to_error_cause(ex, tb)])

--- a/cloudify_tf/terraform/tflint.py
+++ b/cloudify_tf/terraform/tflint.py
@@ -200,7 +200,7 @@ class TFLint(TFTool):
 
     @contextmanager
     def configfile(self):
-        with NamedTemporaryFile() as tflint_cfg:
+        with NamedTemporaryFile(dir=self.terraform_root_module) as tflint_cfg:
             tflint_cfg.write(self.config.encode('utf-8'))
             tflint_cfg.flush()
             try:


### PR DESCRIPTION
When in clustered manager there is some delay in sync (or sync doesn't work properly) there are some issues with failing deployments - these fixes add retries on failures potentially caused by synchronisation issues.