### PR TITLE
return_output fix in execute() function

### DIFF
--- a/cloudify_tf/terraform/__init__.py
+++ b/cloudify_tf/terraform/__init__.py
@@ -222,7 +222,9 @@ class Terraform(CliTool):
         return final_flags
 
     def execute(self, command, return_output=None):
-        return_output = return_output or self._log_stdout
+        return_output = return_output if return_output is not None \
+            else self._log_stdout
+        self.additional_args['log_stdout'] = return_output
         return run_subprocess(
             command,
             self.logger,


### PR DESCRIPTION
return_output for terraform module nodes is omitted even if it's set to False.
The fix ensures the return_output flag actually enables or disables printing the command output to the logs during the execution.